### PR TITLE
Migrate segment decryption logic into segment loader

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -53,7 +53,7 @@
                                                           media.segments,
                                                           media.mediaSequence - playlist.mediaSequence);
           }
-          // resolve any missing segment URIs
+          // resolve any missing segment and key URIs
           j = 0;
           if (result.playlists[i].segments) {
             j = result.playlists[i].segments.length;
@@ -62,6 +62,9 @@
             segment = result.playlists[i].segments[j];
             if (!segment.resolvedUri) {
               segment.resolvedUri = resolveUrl(playlist.resolvedUri, segment.uri);
+            }
+            if (segment.key && !segment.key.resolvedUri) {
+              segment.key.resolvedUri = resolveUrl(playlist.resolvedUri, segment.key.uri);
             }
           }
           changed = true;

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -218,6 +218,7 @@ videojs.HlsHandler.prototype.src = function(src) {
     this.segments.pause();
   }.bind(this));
   this.playlists.on('mediachange', function() {
+    this.segments.abort();
     this.segments.load();
     this.tech_.trigger({
       type: 'mediachange',
@@ -602,9 +603,6 @@ videojs.HlsHandler.prototype.updateDuration = function(playlist) {
  * state suitable for switching to a different video.
  */
 videojs.HlsHandler.prototype.resetSrc_ = function() {
-  this.cancelSegmentXhr();
-  this.cancelKeyXhr();
-
   if (this.sourceBuffer && this.mediaSource.readyState === 'open') {
     this.sourceBuffer.abort();
   }

--- a/test/playlist-loader_test.js
+++ b/test/playlist-loader_test.js
@@ -203,6 +203,54 @@
           'resolved segment URI');
   });
 
+  test('recognizes key URLs relative to master and playlist', function() {
+    var loader = new videojs.Hls.PlaylistLoader('video/media-encrypted.m3u8');
+    requests.shift().respond(200, null,
+                             '#EXTM3U\n' +
+                             '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=17\n' +
+                             'playlist/playlist.m3u8\n' +
+                             '#EXT-X-ENDLIST\n');
+    equal(loader.master.playlists[0].resolvedUri,
+          window.location.protocol + '//' +
+          window.location.host + '/video/playlist/playlist.m3u8',
+          'resolved media URI');
+
+    requests.shift().respond(200, null,
+                             '#EXTM3U\n' +
+                             '#EXT-X-TARGETDURATION:15\n' +
+                             '#EXT-X-KEY:METHOD=AES-128,URI="keys/key.php"\n' +
+                             '#EXTINF:2.833,\n' +
+                             'http://example.com/000001.ts\n' +
+                             '#EXT-X-ENDLIST\n');
+    equal(loader.media().segments[0].key.resolvedUri,
+          window.location.protocol + '//' +
+          window.location.host + '/video/playlist/keys/key.php',
+          'resolved multiple relative paths for key URI');
+  });
+
+  test('recognizes absolute key URLs', function() {
+    var loader = new videojs.Hls.PlaylistLoader('video/media-encrypted.m3u8');
+    requests.shift().respond(200, null,
+                             '#EXTM3U\n' +
+                             '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=17\n' +
+                             'playlist/playlist.m3u8\n' +
+                             '#EXT-X-ENDLIST\n');
+    equal(loader.master.playlists[0].resolvedUri,
+          window.location.protocol + '//' +
+          window.location.host + '/video/playlist/playlist.m3u8',
+          'resolved media URI');
+
+    requests.shift().respond(200, null,
+                             '#EXTM3U\n' +
+                             '#EXT-X-TARGETDURATION:15\n' +
+                             '#EXT-X-KEY:METHOD=AES-128,URI="http://example.com/keys/key.php"\n' +
+                             '#EXTINF:2.833,\n' +
+                             'http://example.com/000001.ts\n' +
+                             '#EXT-X-ENDLIST\n');
+    equal(loader.media().segments[0].key.resolvedUri, 'http://example.com/keys/key.php',
+          'resolved absolute path for key URI');
+  });
+
   test('moves to HAVE_CURRENT_METADATA when refreshing the playlist', function() {
     var loader = new videojs.Hls.PlaylistLoader('live.m3u8');
     requests.pop().respond(200, null,


### PR DESCRIPTION
Resolve key URIs during playlist load (when segment URIs are resolved). Abort both key and segment requests during segment loader aborts. Reset bandwidth calculation on key timeouts, and send up any key request errors. Abort both key and segment requests on mediachange.
